### PR TITLE
CMake build for FMUs and CI configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@
 *.exe
 *.out
 *.app
+
+# Build artifacts
+build/
+temp/
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: c
+
+os:
+  - linux
+  - osx
+
+script:
+  - mkdir -p build
+  - cd build
+  - cmake "Unix Makefiles" ..
+  - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,113 @@
+cmake_minimum_required (VERSION 3.2)
+
+FUNCTION(cat IN_FILE OUT_FILE)
+  file(READ ${IN_FILE} CONTENTS)
+  file(APPEND ${OUT_FILE} "${CONTENTS}")
+ENDFUNCTION()
+
+project (FMUSDK)
+
+if (WIN32)
+   set(FMI_PLATFORM win)
+elseif (APPLE)
+   set(FMI_PLATFORM darwin)
+else ()
+   set(FMI_PLATFORM linux)
+endif ()
+
+if ("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
+    set (FMI_PLATFORM ${FMI_PLATFORM}64)
+else ()
+    set (FMI_PLATFORM ${FMI_PLATFORM}32)
+endif ()
+
+MESSAGE("FMI_PLATFORM: " ${FMI_PLATFORM})
+
+foreach (FMI_VERSION 10 20)
+foreach (FMI_TYPE cs me)
+foreach (MODEL_NAME bouncingBall dq inc values vanDerPol)
+
+set(TARGET_NAME ${MODEL_NAME}_${FMI_VERSION}_${FMI_TYPE})
+
+add_library(${TARGET_NAME} SHARED fmu${FMI_VERSION}/src/models/${MODEL_NAME}/${MODEL_NAME}.c)
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dist/fmi${FMI_VERSION}/${FMI_TYPE})
+
+target_compile_definitions(${TARGET_NAME} PRIVATE DISABLE_PREFIX)
+
+target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/fmu${FMI_VERSION}/src/models")
+
+if (${FMI_VERSION} EQUAL 10)
+  if (${FMI_TYPE} STREQUAL "cs")
+    target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/fmu10/src/co_simulation/include")
+  else ()
+    target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/fmu10/src/model_exchange/include")
+  endif ()
+else ()
+  target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/fmu20/src/shared/include")
+endif()
+
+if (${FMI_TYPE} MATCHES "cs")
+  set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_DEFINITIONS "FMI_COSIMULATION")
+endif()
+
+set(FMU_BUILD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/temp/fmi${FMI_VERSION}/${FMI_TYPE}/${MODEL_NAME})
+
+set_target_properties(${TARGET_NAME} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY         "${FMU_BUILD_DIR}/binaries/${FMI_PLATFORM}"
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG   "${FMU_BUILD_DIR}/binaries/${FMI_PLATFORM}"
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE "${FMU_BUILD_DIR}/binaries/${FMI_PLATFORM}"
+    LIBRARY_OUTPUT_DIRECTORY         "${FMU_BUILD_DIR}/binaries/${FMI_PLATFORM}"
+    LIBRARY_OUTPUT_DIRECTORY_DEBUG   "${FMU_BUILD_DIR}/binaries/${FMI_PLATFORM}"
+    LIBRARY_OUTPUT_DIRECTORY_RELEASE "${FMU_BUILD_DIR}/binaries/${FMI_PLATFORM}"
+    ARCHIVE_OUTPUT_DIRECTORY         "${FMU_BUILD_DIR}/binaries/${FMI_PLATFORM}"
+    ARCHIVE_OUTPUT_DIRECTORY_DEBUG   "${FMU_BUILD_DIR}/binaries/${FMI_PLATFORM}"
+    ARCHIVE_OUTPUT_DIRECTORY_RELEASE "${FMU_BUILD_DIR}/binaries/${FMI_PLATFORM}"
+)
+
+set_target_properties(${TARGET_NAME} PROPERTIES PREFIX "")
+set_target_properties(${TARGET_NAME} PROPERTIES OUTPUT_NAME ${MODEL_NAME})
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+
+if (${FMI_VERSION} EQUAL 10)
+
+file(WRITE ${FMU_BUILD_DIR}/modelDescription.xml "")
+cat(${CMAKE_CURRENT_SOURCE_DIR}/fmu10/src/models/${MODEL_NAME}/modelDescription.xml ${FMU_BUILD_DIR}/modelDescription.xml )
+cat(${CMAKE_CURRENT_SOURCE_DIR}/fmu10/src/models/${FMI_TYPE}.xml ${FMU_BUILD_DIR}/modelDescription.xml )
+
+else()
+
+add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
+  ${CMAKE_CURRENT_SOURCE_DIR}/fmu20/src/models/${MODEL_NAME}/modelDescription_${FMI_TYPE}.xml
+  "${FMU_BUILD_DIR}/modelDescription.xml"
+)
+
+endif()
+
+add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
+  "${CMAKE_CURRENT_SOURCE_DIR}/fmu${FMI_VERSION}/src/models/${MODEL_NAME}/${MODEL_NAME}.c"
+  "${FMU_BUILD_DIR}/sources/${MODEL_NAME}.c"
+)
+
+add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
+  "${CMAKE_CURRENT_SOURCE_DIR}/fmu${FMI_VERSION}/src/models/fmuTemplate.c"
+  "${FMU_BUILD_DIR}/sources/fmuTemplate.c"
+)
+
+add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
+  "${CMAKE_CURRENT_SOURCE_DIR}/fmu${FMI_VERSION}/src/models/fmuTemplate.h"
+  "${FMU_BUILD_DIR}/sources/fmuTemplate.h"
+)
+
+add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${CMAKE_CURRENT_SOURCE_DIR}/dist/fmi${FMI_VERSION}/${FMI_TYPE}/${MODEL_NAME}.fmu" --format=zip
+  "modelDescription.xml"
+  "binaries"
+  "sources"
+  WORKING_DIRECTORY ${FMU_BUILD_DIR}
+)
+
+endforeach(MODEL_NAME)
+endforeach(FMI_TYPE)
+endforeach(FMI_VERSION)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Travis CI](https://travis-ci.org/t-sommer/fmusdk.svg?branch=master)](https://travis-ci.org/t-sommer/fmusdk)
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/github/t-sommer/fmusdk?svg=true)](https://ci.appveyor.com/project/TorstenSommer/fmusdk)
+
 # FMU SDK
 
 The FMU SDK is a free software development kit provided by [QTronic](https://www.qtronic.de/). It demonstrates basic use of Functional Mockup Units (FMUs) as defined by the following Functional Mock-up Interface specifications for
@@ -27,6 +30,33 @@ Compilation using install.bat requires that you have installed one of Microsoft 
 
 To build Linux or Mac OS X binaries of all FMUs and simulators, open command shell and run `make`. The build requires that you have installed the C and C++ compilers, libexpat and libxml2 libraries. To install these dependencies on Linux you can use a package manager like `sudo apt install g++`, `sudo apt install libexpat1-dev`, `sudo apt install libxml2-dev`.
 
+### Building the FMUs with CMake
+
+Install [CMake](https://cmake.org/) 3.2 or later, open a command line and change into the folder where you've cloned or extracted the FMU SDK.
+
+On Mac and Linux enter
+
+```
+mkdir build
+cmake -G "Unix Makefiles" ..
+make
+```
+
+on Windows enter
+
+```
+mkdir build
+cmake -G "Visual Studio 14 2015 Win64" ..
+msbuild FMUSDK.sln
+```
+
+which builds all FMUs into the `dist` folder. To get a list of the available generators enter
+
+```
+cmake --help
+```
+
+Alternatively you can use [CMake's graphical user interface](https://cmake.org/runningcmake/) to generate the build pipeline. 
 
 ## Simulating an FMU
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+clone_folder: c:\projects\fmusdk
+
+image:
+  - Visual Studio 2015
+
+before_build:
+  - cmd: |-
+      mkdir build
+      cd build
+      cmake -G "Visual Studio 14 2015 Win64" ..
+
+build:
+  project: c:\projects\fmusdk\build\FMUSDK.sln
+
+artifacts:
+  - path: dist


### PR DESCRIPTION
Hi @adriantirea, as promised here's the CMake build configuration. Once you've merged the PR you have to connect your repository to the AppVeyor (Windows) and Travis-CI (Linux & Mac) integration services and update the status badges in the README.md accordingly to enable the automatic integration build. Both services are free for open source projects.